### PR TITLE
Dockerize it

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM crystallang/crystal:latest
+
+ADD . /src
+WORKDIR /src
+RUN shards install
+
+CMD ["crystal", "spec"]

--- a/README.md
+++ b/README.md
@@ -67,6 +67,17 @@ Hardware::CPU.used #=> 12
 
 ```
 
+## Development
+
+### Docker
+
+You can run the specs in a Docker container:
+
+```sh
+$ docker-compose up
+$ docker-compose run spec
+```
+
 ## Contributing
 
 1. Fork it ( https://github.com/crystal-community/hardware/fork )

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,7 @@
+version: '3'
+
+services:
+  spec:
+    build: .
+    volumes:
+      - .:/src


### PR DESCRIPTION
Since the shard supports only Linux environment, this PR adds a suggestion how to do the development on other environments (via the Docker). I'm on Mac OSX, so:

```sh
hardware git:feat/docker ❯ crystal spec                                                                                                                                                                  
E.

Failures:

  1) Hardware::CPU parses '/proc/stat'

       Error opening file '/proc/stat' with mode 'r': No such file or directory
       /usr/local/Cellar/crystal-lang/0.24.2_1/src/file.cr:33:5 in 'initialize'
       /usr/local/Cellar/crystal-lang/0.24.2_1/src/file.cr:25:3 in 'new'
       /usr/local/Cellar/crystal-lang/0.24.2_1/src/file.cr:427:5 in 'read'
       /usr/local/Cellar/crystal-lang/0.24.2_1/src/file.cr:441:3 in 'read'
       src/hardware/cpu.cr:3:11 in 'info'
       ~procProc(Nil)@spec/cpu_spec.cr:4
       /usr/local/Cellar/crystal-lang/0.24.2_1/src/spec/methods.cr:255:3 in 'it'
       ~procProc(Nil)@spec/cpu_spec.cr:3
       /usr/local/Cellar/crystal-lang/0.24.2_1/src/spec/context.cr:255:3 in 'describe'
       /usr/local/Cellar/crystal-lang/0.24.2_1/src/spec/methods.cr:16:5 in 'describe'
       spec/hardware_spec.cr:1:1 in '__crystal_main'
       /usr/local/Cellar/crystal-lang/0.24.2_1/src/crystal/main.cr:11:3 in '_crystal_main'
       /usr/local/Cellar/crystal-lang/0.24.2_1/src/crystal/main.cr:112:5 in 'main_user_code'
       /usr/local/Cellar/crystal-lang/0.24.2_1/src/crystal/main.cr:101:7 in 'main'
       /usr/local/Cellar/crystal-lang/0.24.2_1/src/crystal/main.cr:135:3 in 'main'

Finished in 175 microseconds
2 examples, 0 failures, 1 errors, 0 pending

Failed examples:

crystal spec spec/cpu_spec.cr:4 

hardware git:master ❯ docker-compose up                                                                                                                                                                 
Starting hardware_spec_1 ... done
Attaching to hardware_spec_1
spec_1  | ........
spec_1  |
spec_1  | Finished in 679 microseconds
spec_1  | 8 examples, 0 failures, 0 errors, 0 pending
hardware_spec_1 exited with code 0

hardware git:master ❯ docker-compose run spec                                                                                                                                                          
........

Finished in 578 microseconds
8 examples, 0 failures, 0 errors, 0 pending
```

Since the source files are mounted into the container, it is possible to edit the files as usual and run specs in docker. 
