### PR TITLE
Change to not rounded Float32 values by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,12 +64,12 @@ Returns the memory used in KiloBytes.
 require "hardware"
 
 memory = Hardware::Memory.new
-memory.used        #=> 2731404
-memory.percent     #=> 32
+memory.used            #=> 2731404
+memory.percent.to_i    #=> 32
 
-Hardware::CPU.used #=> 12
+Hardware::CPU.used.to_i #=> 12
 Hardware::CPU.each_use do |cpu|
-  cpu              #=> 17
+  cpu.to_i              #=> 17
 end
 ```
 

--- a/src/hardware/cpu.cr
+++ b/src/hardware/cpu.cr
@@ -16,7 +16,7 @@ module Hardware::CPU
       proc_now = info
 
       # 100 * Usage / Total
-      yield (100 * ((proc_now[:used] - proc_last[:used]).to_f32 / (proc_now[:total] - proc_last[:total]))).round
+      yield (proc_now[:used] - proc_last[:used]).to_f32 / (proc_now[:total] - proc_last[:total]) * 100
       proc_last = proc_now
     end
   end

--- a/src/hardware/memory.cr
+++ b/src/hardware/memory.cr
@@ -29,6 +29,6 @@ struct Hardware::Memory
   end
 
   def percent(used = true)
-    ((used ? self.used : available) * 100 / total).round
+    (used ? self.used : available).to_f32 * 100 / total
   end
 end


### PR DESCRIPTION
Don't impose a round - `to_i` or `round` can be used after.
Fix #9.