### PR TITLE
Improvements for Hardware::Pid::Status

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: hardware
-version: 0.5.2
+version: 0.5.3
 
 authors:
   - bararchy <bar.hofesh@safe-t.com>

--- a/src/pid.cr
+++ b/src/pid.cr
@@ -112,9 +112,7 @@ struct Hardware::PID
 
   # Returns a parsed `/proc/``#pid``/status`.
   def status : Status
-    read_proc "status" do |io|
-      Status.new io
-    end
+    name.size > 0 ? Status.new read_proc "status", &.gets_to_end : Status.new nil
   end
 end
 

--- a/src/pid.cr
+++ b/src/pid.cr
@@ -112,7 +112,9 @@ struct Hardware::PID
 
   # Returns a parsed `/proc/``#pid``/status`.
   def status : Status
-    name.size > 0 ? Status.new read_proc "status", &.gets_to_end : Status.new nil
+    read_proc "status" do |io|
+      Status.new io
+    end
   end
 end
 

--- a/src/pid/status.cr
+++ b/src/pid/status.cr
@@ -1,60 +1,159 @@
 struct Hardware::PID::Status
-  getter data : Hash(String, String)
+  getter data : Hash(String, String) = {
+    "Name"                       => "",
+    "Umask"                      => "",
+    "State"                      => "",
+    "Tgid"                       => "",
+    "Ngid"                       => "",
+    "Pid"                        => "",
+    "PPid"                       => "",
+    "TracerPid"                  => "",
+    "Uid"                        => "",
+    "Gid"                        => "",
+    "FDSize"                     => "",
+    "Groups"                     => "",
+    "NStgid"                     => "",
+    "NSpid"                      => "",
+    "NSpgid"                     => "",
+    "NSsid"                      => "",
+    "VmPeak"                     => "",
+    "VmSize"                     => "",
+    "VmLck"                      => "",
+    "VmPin"                      => "",
+    "VmHWM"                      => "",
+    "VmRSS"                      => "",
+    "RssAnon"                    => "",
+    "RssFile"                    => "",
+    "RssShmem"                   => "",
+    "VmData"                     => "",
+    "VmStk"                      => "",
+    "VmExe"                      => "",
+    "VmLib"                      => "",
+    "VmPTE"                      => "",
+    "VmSwap"                     => "",
+    "HugetlbPages"               => "",
+    "CoreDumping"                => "",
+    "THP_enabled"                => "",
+    "Threads"                    => "",
+    "SigQ"                       => "",
+    "SigPnd"                     => "",
+    "ShdPnd"                     => "",
+    "SigBlk"                     => "",
+    "SigIgn"                     => "",
+    "SigCgt"                     => "",
+    "CapInh"                     => "",
+    "CapPrm"                     => "",
+    "CapEff"                     => "",
+    "CapBnd"                     => "",
+    "CapAmb"                     => "",
+    "NoNewPrivs"                 => "",
+    "Seccomp"                    => "",
+    "Seccomp_filters"            => "",
+    "Speculation_Store_Bypass"   => "",
+    "SpeculationIndirectBranch"  => "",
+    "Cpus_allowed"               => "",
+    "Cpus_allowed_list"          => "",
+    "Mems_allowed"               => "",
+    "Mems_allowed_list"          => "",
+    "voluntary_ctxt_switches"    => "",
+    "nonvoluntary_ctxt_switches" => "",
+  }
 
-  def initialize(file_content : String?)
-    @data = {
-      "Name"         => "",
-      "Umask"        => "",
-      "State"        => "",
-      "Tgid"         => "",
-      "Ngid"         => "",
-      "Pid"          => "",
-      "PPid"         => "",
-      "TracerPid"    => "",
-      "Uid"          => "",
-      "Gid"          => "",
-      "FDSize"       => "",
-      "Groups"       => "",
-      "NStgid"       => "",
-      "NSpid"        => "",
-      "NSpgid"       => "",
-      "NSsid"        => "",
-      "VmPeak"       => "",
-      "VmSize"       => "",
-      "VmLck"        => "",
-      "VmPin"        => "",
-      "VmHWM"        => "",
-      "VmRSS"        => "",
-      "RssAnon"      => "",
-      "RssFile"      => "",
-      "RssShmem"     => "",
-      "VmData"       => "",
-      "VmStk"        => "",
-      "VmExe"        => "",
-      "VmLib"        => "",
-      "VmPTE"        => "",
-      "VmSwap"       => "",
-      "HugetlbPages" => "",
-      "CoreDumping"  => "",
-      "THP_enabled"  => "",
-      "Threads"      => "",
-    }
+  getter name : String { @data["Name"] }
+  getter umask : String { @data["Umask"] }
+  getter state : String { @data["State"] }
+  getter tgid : String { @data["Tgid"] }
+  getter ngid : String { @data["Ngid"] }
+  getter pid : String { @data["Pid"] }
+  getter ppid : String { @data["PPid"] }
+  getter tracerpid : String { @data["TracerPid"] }
+  getter uid : String { @data["Uid"] }
+  getter gid : String { @data["Gid"] }
+  getter fdsize : String { @data["FDSize"] }
+  getter groups : String { @data["Groups"] }
+  getter nstgid : String { @data["NStgid"] }
+  getter nspid : String { @data["NSpid"] }
+  getter nspgid : String { @data["NSpgid"] }
+  getter nssid : String { @data["NSsid"] }
+  getter vmpeak : String { @data["VmPeak"] }
+  getter vmsize : String { @data["VmSize"] }
+  getter vmlck : String { @data["VmLck"] }
+  getter vmpin : String { @data["VmPin"] }
+  getter vmhwm : String { @data["VmHWM"] }
+  getter vmrss : String { @data["VmRSS"] }
+  getter rssanon : String { @data["RssAnon"] }
+  getter rssfile : String { @data["RssFile"] }
+  getter rssshmem : String { @data["RssShmem"] }
+  getter vmdata : String { @data["VmData"] }
+  getter vmstk : String { @data["VmStk"] }
+  getter vmexe : String { @data["VmExe"] }
+  getter vmlib : String { @data["VmLib"] }
+  getter vmpte : String { @data["VmPTE"] }
+  getter vmswap : String { @data["VmSwap"] }
+  getter hugetlbpages : String { @data["HugetlbPages"] }
+  getter coredumping : String { @data["CoreDumping"] }
+  getter thp_enabled : String { @data["THP_enabled"] }
+  getter threads : String { @data["Threads"] }
+  getter sigq : String { @data["SigQ"] }
+  getter sigpnd : String { @data["SigPnd"] }
+  getter shdpnd : String { @data["ShdPnd"] }
+  getter sigblk : String { @data["SigBlk"] }
+  getter sigign : String { @data["SigIgn"] }
+  getter sigcgt : String { @data["SigCgt"] }
+  getter capinh : String { @data["CapInh"] }
+  getter capprm : String { @data["CapPrm"] }
+  getter capeff : String { @data["CapEff"] }
+  getter capbnd : String { @data["CapBnd"] }
+  getter capamb : String { @data["CapAmb"] }
+  getter nonewprivs : String { @data["NoNewPrivs"] }
+  getter seccomp : String { @data["Seccomp"] }
+  getter seccomp_filters : String { @data["Seccomp_filters"] }
+  getter speculation_store_bypass : String { @data["Speculation_Store_Bypass"] }
+  getter speculationindirectbranch : String { @data["SpeculationIndirectBranch"] }
+  getter cpus_allowed : String { @data["Cpus_allowed"] }
+  getter cpus_allowed_list : String { @data["Cpus_allowed_list"] }
+  getter mems_allowed : String { @data["Mems_allowed"] }
+  getter mems_allowed_list : String { @data["Mems_allowed_list"] }
+  getter voluntary_ctxt_switches : String { @data["voluntary_ctxt_switches"] }
+  getter nonvoluntary_ctxt_switches : String { @data["nonvoluntary_ctxt_switches"] }
 
-    return unless file_content
-
-    file_content.each_line do |l|
-      key, value = l.delete(' ').delete('\t').split(':')
-      @data[key] = value
-      break if key == "Threads"
-    end
+  enum ReadState
+    Key
+    Blank
+    Value
   end
 
-  # PID's status name.
-  getter name : String { @data["Name"] }
+  protected def initialize(io : IO)
+    buffer = IO::Memory.new
+    key = ""
+    state = ReadState::Key
 
-  # PID's status umask.
-  getter umask : String { @data["Umask"] }
-
-  # PID's status state.
-  getter state : String { @data["State"] }
+    io.each_char do |char|
+      case state
+      when ReadState::Key
+        if char == ':'
+          key = buffer.to_s
+          buffer.clear
+          state = ReadState::Blank
+        else
+          buffer << char
+        end
+      when ReadState::Blank
+        if char.alphanumeric?
+          buffer << char
+          state = ReadState::Value
+        end
+      when ReadState::Value
+        if char == '\n'
+          data[key] = buffer.to_s
+          buffer.clear
+          state = ReadState::Key
+          break if key == "Threads"
+          key = ""
+        else
+          buffer << char
+        end
+      end
+    end
+  end
 end

--- a/src/pid/status.cr
+++ b/src/pid/status.cr
@@ -1,74 +1,73 @@
 struct Hardware::PID::Status
-  getter data : Hash(String, String) = {
-    "Name"                       => "",
-    "Umask"                      => "",
-    "State"                      => "",
-    "Tgid"                       => "",
-    "Ngid"                       => "",
-    "Pid"                        => "",
-    "PPid"                       => "",
-    "TracerPid"                  => "",
-    "Uid"                        => "",
-    "Gid"                        => "",
-    "FDSize"                     => "",
-    "Groups"                     => "",
-    "NStgid"                     => "",
-    "NSpid"                      => "",
-    "NSpgid"                     => "",
-    "NSsid"                      => "",
-    "VmPeak"                     => "",
-    "VmSize"                     => "",
-    "VmLck"                      => "",
-    "VmPin"                      => "",
-    "VmHWM"                      => "",
-    "VmRSS"                      => "",
-    "RssAnon"                    => "",
-    "RssFile"                    => "",
-    "RssShmem"                   => "",
-    "VmData"                     => "",
-    "VmStk"                      => "",
-    "VmExe"                      => "",
-    "VmLib"                      => "",
-    "VmPTE"                      => "",
-    "VmSwap"                     => "",
-    "HugetlbPages"               => "",
-    "CoreDumping"                => "",
-    "THP_enabled"                => "",
-    "Threads"                    => "",
-    "SigQ"                       => "",
-    "SigPnd"                     => "",
-    "ShdPnd"                     => "",
-    "SigBlk"                     => "",
-    "SigIgn"                     => "",
-    "SigCgt"                     => "",
-    "CapInh"                     => "",
-    "CapPrm"                     => "",
-    "CapEff"                     => "",
-    "CapBnd"                     => "",
-    "CapAmb"                     => "",
-    "NoNewPrivs"                 => "",
-    "Seccomp"                    => "",
-    "Seccomp_filters"            => "",
-    "Speculation_Store_Bypass"   => "",
-    "SpeculationIndirectBranch"  => "",
-    "Cpus_allowed"               => "",
-    "Cpus_allowed_list"          => "",
-    "Mems_allowed"               => "",
-    "Mems_allowed_list"          => "",
-    "voluntary_ctxt_switches"    => "",
-    "nonvoluntary_ctxt_switches" => "",
-  }
 
-  macro define_getters(*keys)
-    {% for key in keys %}
-      def {{ key.downcase.id }}
-        {{ @data[key] }}
-      end
-    {% end %}
-  end
+  KEYS = [
+    "Name",
+    "Umask",
+    "State",
+    "Tgid",
+    "Ngid",
+    "Pid",
+    "PPid",
+    "TracerPid",
+    "Uid",
+    "Gid",
+    "FDSize",
+    "Groups",
+    "NStgid",
+    "NSpid",
+    "NSpgid",
+    "NSsid",
+    "VmPeak",
+    "VmSize",
+    "VmLck",
+    "VmPin",
+    "VmHWM",
+    "VmRSS",
+    "RssAnon",
+    "RssFile",
+    "RssShmem",
+    "VmData",
+    "VmStk",
+    "VmExe",
+    "VmLib",
+    "VmPTE",
+    "VmSwap",
+    "HugetlbPages",
+    "CoreDumping",
+    "THP_enabled",
+    "Threads",
+    "SigQ",
+    "SigPnd",
+    "ShdPnd",
+    "SigBlk",
+    "SigIgn",
+    "SigCgt",
+    "CapInh",
+    "CapPrm",
+    "CapEff",
+    "CapBnd",
+    "CapAmb",
+    "NoNewPrivs",
+    "Seccomp",
+    "Seccomp_filters",
+    "Speculation_Store_Bypass",
+    "SpeculationIndirectBranch",
+    "Cpus_allowed",
+    "Cpus_allowed_list",
+    "Mems_allowed",
+    "Mems_allowed_list",
+    "voluntary_ctxt_switches",
+    "nonvoluntary_ctxt_switches"
+  ]	
+
+  getter data : Hash(String, String)
+
+  {% for key in KEYS %}
+    def {{ key.downcase.id }}
+      data[{{key}}]
+    end
+  {% end %}
   
-  define_getters @data.keys
- 
   enum Field
     Key
     Blank
@@ -76,6 +75,8 @@ struct Hardware::PID::Status
   end
 
   protected def initialize(io : IO)
+    @data = Hash(String, String).new
+    KEYS.each { |k| @data[k] = "" }
     buffer = IO::Memory.new
     key = ""
     state = Field::Key

--- a/src/pid/status.cr
+++ b/src/pid/status.cr
@@ -148,7 +148,6 @@ struct Hardware::PID::Status
           data[key] = buffer.to_s
           buffer.clear
           state = ReadState::Key
-          break if key == "Threads"
           key = ""
         else
           buffer << char

--- a/src/pid/status.cr
+++ b/src/pid/status.cr
@@ -1,29 +1,58 @@
 struct Hardware::PID::Status
-  getter data : Hash(String, String) = Hash(String, String).new
+  getter data : Hash(String, String)
 
-  protected def initialize(io : IO)
-    @data = Hash(String, String).new
-    buffer = IO::Memory.new
-    key = ""
-    io.each_char do |char|
-      case char
-      when ' '
-        # skip
-      when ':'
-        key = buffer.to_s
-        buffer.clear
-      when '\n'
-        @data[key] = buffer.to_s
-      else
-        buffer << char
-      end
+  def initialize(file_content : String?)
+    @data = {
+      "Name"         => "",
+      "Umask"        => "",
+      "State"        => "",
+      "Tgid"         => "",
+      "Ngid"         => "",
+      "Pid"          => "",
+      "PPid"         => "",
+      "TracerPid"    => "",
+      "Uid"          => "",
+      "Gid"          => "",
+      "FDSize"       => "",
+      "Groups"       => "",
+      "NStgid"       => "",
+      "NSpid"        => "",
+      "NSpgid"       => "",
+      "NSsid"        => "",
+      "VmPeak"       => "",
+      "VmSize"       => "",
+      "VmLck"        => "",
+      "VmPin"        => "",
+      "VmHWM"        => "",
+      "VmRSS"        => "",
+      "RssAnon"      => "",
+      "RssFile"      => "",
+      "RssShmem"     => "",
+      "VmData"       => "",
+      "VmStk"        => "",
+      "VmExe"        => "",
+      "VmLib"        => "",
+      "VmPTE"        => "",
+      "VmSwap"       => "",
+      "HugetlbPages" => "",
+      "CoreDumping"  => "",
+      "THP_enabled"  => "",
+      "Threads"      => "",
+    }
+
+    return unless file_content
+
+    file_content.each_line do |l|
+      key, value = l.delete(' ').delete('\t').split(':')
+      @data[key] = value
+      break if key == "Threads"
     end
   end
 
   # PID's status name.
   getter name : String { @data["Name"] }
 
-  # PID's status state.
+  # PID's status umask.
   getter umask : String { @data["Umask"] }
 
   # PID's status state.

--- a/src/pid/status.cr
+++ b/src/pid/status.cr
@@ -59,65 +59,17 @@ struct Hardware::PID::Status
     "nonvoluntary_ctxt_switches" => "",
   }
 
-  getter name : String { @data["Name"] }
-  getter umask : String { @data["Umask"] }
-  getter state : String { @data["State"] }
-  getter tgid : String { @data["Tgid"] }
-  getter ngid : String { @data["Ngid"] }
-  getter pid : String { @data["Pid"] }
-  getter ppid : String { @data["PPid"] }
-  getter tracerpid : String { @data["TracerPid"] }
-  getter uid : String { @data["Uid"] }
-  getter gid : String { @data["Gid"] }
-  getter fdsize : String { @data["FDSize"] }
-  getter groups : String { @data["Groups"] }
-  getter nstgid : String { @data["NStgid"] }
-  getter nspid : String { @data["NSpid"] }
-  getter nspgid : String { @data["NSpgid"] }
-  getter nssid : String { @data["NSsid"] }
-  getter vmpeak : String { @data["VmPeak"] }
-  getter vmsize : String { @data["VmSize"] }
-  getter vmlck : String { @data["VmLck"] }
-  getter vmpin : String { @data["VmPin"] }
-  getter vmhwm : String { @data["VmHWM"] }
-  getter vmrss : String { @data["VmRSS"] }
-  getter rssanon : String { @data["RssAnon"] }
-  getter rssfile : String { @data["RssFile"] }
-  getter rssshmem : String { @data["RssShmem"] }
-  getter vmdata : String { @data["VmData"] }
-  getter vmstk : String { @data["VmStk"] }
-  getter vmexe : String { @data["VmExe"] }
-  getter vmlib : String { @data["VmLib"] }
-  getter vmpte : String { @data["VmPTE"] }
-  getter vmswap : String { @data["VmSwap"] }
-  getter hugetlbpages : String { @data["HugetlbPages"] }
-  getter coredumping : String { @data["CoreDumping"] }
-  getter thp_enabled : String { @data["THP_enabled"] }
-  getter threads : String { @data["Threads"] }
-  getter sigq : String { @data["SigQ"] }
-  getter sigpnd : String { @data["SigPnd"] }
-  getter shdpnd : String { @data["ShdPnd"] }
-  getter sigblk : String { @data["SigBlk"] }
-  getter sigign : String { @data["SigIgn"] }
-  getter sigcgt : String { @data["SigCgt"] }
-  getter capinh : String { @data["CapInh"] }
-  getter capprm : String { @data["CapPrm"] }
-  getter capeff : String { @data["CapEff"] }
-  getter capbnd : String { @data["CapBnd"] }
-  getter capamb : String { @data["CapAmb"] }
-  getter nonewprivs : String { @data["NoNewPrivs"] }
-  getter seccomp : String { @data["Seccomp"] }
-  getter seccomp_filters : String { @data["Seccomp_filters"] }
-  getter speculation_store_bypass : String { @data["Speculation_Store_Bypass"] }
-  getter speculationindirectbranch : String { @data["SpeculationIndirectBranch"] }
-  getter cpus_allowed : String { @data["Cpus_allowed"] }
-  getter cpus_allowed_list : String { @data["Cpus_allowed_list"] }
-  getter mems_allowed : String { @data["Mems_allowed"] }
-  getter mems_allowed_list : String { @data["Mems_allowed_list"] }
-  getter voluntary_ctxt_switches : String { @data["voluntary_ctxt_switches"] }
-  getter nonvoluntary_ctxt_switches : String { @data["nonvoluntary_ctxt_switches"] }
-
-  enum ReadState
+  macro define_getters(*keys)
+    {% for key in keys %}
+      def {{ key.downcase.id }}
+        {{ @data[key] }}
+      end
+    {% end %}
+  end
+  
+  define_getters @data.keys
+ 
+  enum Field
     Key
     Blank
     Value
@@ -126,33 +78,37 @@ struct Hardware::PID::Status
   protected def initialize(io : IO)
     buffer = IO::Memory.new
     key = ""
-    state = ReadState::Key
+    state = Field::Key
 
     io.each_char do |char|
+      
       case state
-      when ReadState::Key
+      when Field::Key
         if char == ':'
           key = buffer.to_s
           buffer.clear
-          state = ReadState::Blank
+          state = Field::Blank
         else
           buffer << char
         end
-      when ReadState::Blank
+      
+      when Field::Blank
         if char.alphanumeric?
           buffer << char
-          state = ReadState::Value
+          state = Field::Value
         end
-      when ReadState::Value
+    
+      when Field::Value
         if char == '\n'
           data[key] = buffer.to_s
           buffer.clear
-          state = ReadState::Key
+          state = Field::Key
           key = ""
         else
           buffer << char
         end
       end
+
     end
   end
 end

--- a/src/pid/status.cr
+++ b/src/pid/status.cr
@@ -2,7 +2,7 @@ struct Hardware::PID::Status
   getter data : Hash(String, String) = Hash(String, String).new
 
   protected def initialize(io : IO)
-    data = Hash(String, String).new
+    @data = Hash(String, String).new
     buffer = IO::Memory.new
     key = ""
     io.each_char do |char|
@@ -13,7 +13,7 @@ struct Hardware::PID::Status
         key = buffer.to_s
         buffer.clear
       when '\n'
-        data[key] = buffer.to_s
+        @data[key] = buffer.to_s
       else
         buffer << char
       end


### PR DESCRIPTION
* Initialize all keys for data instance variable in order to prevent invalid access to the hash.
* Correctly parse fields in /proc/#/status where value includes whitespace characters (e.g. "Uid: 1000 1000 1000 1000")
* Auto generate getters for Hardware::Pid::Status
* Bugfixes